### PR TITLE
Bugfix: pd.DataFrame.dropna(subset=[]) requires a list as input type

### DIFF
--- a/lessons/03_preprocessing.ipynb
+++ b/lessons/03_preprocessing.ipynb
@@ -223,7 +223,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data = data.dropna(subset='sex')\n",
+    "data = data.dropna(subset=['sex'])\n",
     "\n",
     "# Now this line will return an empty dataframe\n",
     "data[data['sex'].isna()]"
@@ -431,7 +431,7 @@
    "source": [
     "data = pd.read_csv('../data/penguins.csv')\n",
     "data.replace('.', np.nan, inplace=True)\n",
-    "data = data.dropna(subset='sex')\n"
+    "data = data.dropna(subset=['sex'])\n"
    ]
   },
   {


### PR DESCRIPTION
This pull request is to fix a bug that occurs due to a change in the Pandas library interface.
The interface of pd.DataFrame.dropna() changed. 
The argument `subset` no longer accepts inputs of type `string`. 

## Expected behavior

All notebook cells execute without errors.

## Actual behavior

Two cells don't execute.
![image](https://github.com/dlab-berkeley/Python-Machine-Learning/assets/515945/b3088657-7f46-4dad-8a8f-1309c1b9f29c)
![image](https://github.com/dlab-berkeley/Python-Machine-Learning/assets/515945/2d4bdd3e-2b09-4e97-9bf2-e727ff1954f1)

## Problem solution:

Encapsulate `string` in a `list`.